### PR TITLE
Fix download buttons Analytics labels

### DIFF
--- a/index.php
+++ b/index.php
@@ -156,8 +156,8 @@ function getAltLinks(){
 	<header>
 		<img src="images/Quitnow.svg" class="logo" alt="QuitNow!">
 		<span class="stores">
-			<a target="_blank" onClick="ga('send', 'event', 'Downloads', 'iOS', 'Button position', 2);" href="https://itunes.apple.com/app/quitnow!-quit-smoking/id483994930"><img src="images/L10n/<?php echo $lang; ?>/app_store.svg" width="150" height="49" alt="<?php t('badge.applestore'); ?>" class="apple"></a>
-			<a target="_blank" onClick="ga('send', 'event', 'Downloads', 'Android', 'Button position', 2);" href="https://play.google.com/store/apps/details?id=com.EAGINsoftware.dejaloYa&referrer=utm_source%3Dweb%26utm_medium%3Dlink"><img src="images/L10n/<?php echo $lang; ?>/google_play.svg" width="150" height="49" alt="<?php t('badge.googleplay'); ?>" class="android"></a>
+			<a target="_blank" onClick="ga('send', 'event', 'Downloads', 'iOS', 'Header button', 1);" href="https://itunes.apple.com/app/quitnow!-quit-smoking/id483994930"><img src="images/L10n/<?php echo $lang; ?>/app_store.svg" width="150" height="49" alt="<?php t('badge.applestore'); ?>" class="apple"></a>
+			<a target="_blank" onClick="ga('send', 'event', 'Downloads', 'Android', 'Header button', 1);" href="https://play.google.com/store/apps/details?id=com.EAGINsoftware.dejaloYa&referrer=utm_source%3Dweb%26utm_medium%3Dlink"><img src="images/L10n/<?php echo $lang; ?>/google_play.svg" width="150" height="49" alt="<?php t('badge.googleplay'); ?>" class="android"></a>
 		</span>
 	</header>
 	<div id="fullpage">
@@ -169,8 +169,8 @@ function getAltLinks(){
 					<?php t('slogan'); ?>
 				</p>
 				<span class="stores">
-					<a target="_blank" onClick="ga('send', 'event', 'Downloads', 'iOS', 'Button position', 1);" href="https://itunes.apple.com/app/quitnow!-quit-smoking/id483994930"><img src="images/L10n/<?php echo $lang; ?>/app_store.svg" width="150" height="49" alt="<?php t('badge.applestore'); ?>" class="apple"></a>
-					<a target="_blank" onClick="ga('send', 'event', 'Downloads', 'Android', 'Button position', 1);" href="https://play.google.com/store/apps/details?id=com.EAGINsoftware.dejaloYa&referrer=utm_source%3Dweb%26utm_medium%3Dlink"><img src="images/L10n/<?php echo $lang; ?>/google_play.svg" width="150" height="49" alt="<?php t('badge.googleplay'); ?>" class="android"></a>
+					<a target="_blank" onClick="ga('send', 'event', 'Downloads', 'iOS', 'First page button', 1);" href="https://itunes.apple.com/app/quitnow!-quit-smoking/id483994930"><img src="images/L10n/<?php echo $lang; ?>/app_store.svg" width="150" height="49" alt="<?php t('badge.applestore'); ?>" class="apple"></a>
+					<a target="_blank" onClick="ga('send', 'event', 'Downloads', 'Android', 'First page button', 1);" href="https://play.google.com/store/apps/details?id=com.EAGINsoftware.dejaloYa&referrer=utm_source%3Dweb%26utm_medium%3Dlink"><img src="images/L10n/<?php echo $lang; ?>/google_play.svg" width="150" height="49" alt="<?php t('badge.googleplay'); ?>" class="android"></a>
 				</span>
 				<p class="hideOnMobile">
 					<?php getAltLinks(); ?>
@@ -312,8 +312,8 @@ function getAltLinks(){
 					<?php t('last.body'); ?>
 				</p>
 				<div class="stores">
-          <a target="_blank" onClick="ga('send', 'event', 'Downloads', 'iOS', 'Button position', 3);" href="https://itunes.apple.com/app/quitnow!-quit-smoking/id483994930"><img src="images/L10n/<?php echo $lang; ?>/app_store.svg" width="150" height="49" alt="<?php t('badge.applestore'); ?>" class="apple"></a>
-          <a target="_blank" onClick="ga('send', 'event', 'Downloads', 'Android', 'Button position', 3);" href="https://play.google.com/store/apps/details?id=com.EAGINsoftware.dejaloYa&referrer=utm_source%3Dweb%26utm_medium%3Dlink"><img src="images/L10n/<?php echo $lang; ?>/google_play.svg" width="150" height="49" alt="<?php t('badge.googleplay'); ?>" class="android"></a>
+          <a target="_blank" onClick="ga('send', 'event', 'Downloads', 'iOS', 'World page button', 1);" href="https://itunes.apple.com/app/quitnow!-quit-smoking/id483994930"><img src="images/L10n/<?php echo $lang; ?>/app_store.svg" width="150" height="49" alt="<?php t('badge.applestore'); ?>" class="apple"></a>
+          <a target="_blank" onClick="ga('send', 'event', 'Downloads', 'Android', 'World page button', 1);" href="https://play.google.com/store/apps/details?id=com.EAGINsoftware.dejaloYa&referrer=utm_source%3Dweb%26utm_medium%3Dlink"><img src="images/L10n/<?php echo $lang; ?>/google_play.svg" width="150" height="49" alt="<?php t('badge.googleplay'); ?>" class="android"></a>
 				</div>
 				<p class="hxs">
 					<?php getAltLinks(); ?>


### PR DESCRIPTION
Looking at the Analytics, we have this weird situation. Noice! We can't know what button is preferred by users.

<img width="902" alt="screen shot 2018-01-15 at 21 38 14" src="https://user-images.githubusercontent.com/456499/34958881-7b63f40c-fa3c-11e7-8150-3db8c6916568.png">

This PR fixes it, just giving a different label for every button.